### PR TITLE
Customizable exporting files

### DIFF
--- a/scripts/clear-modules.js
+++ b/scripts/clear-modules.js
@@ -6,9 +6,10 @@ const excludedFolders = ['node_modules', 'scripts'];
 export default () => {
   const packageInfo = JSON.parse(fs.readFileSync('package.json', 'utf8'));
   const packageName = packageInfo.name;
+  const dependencies = Object.keys(packageInfo.dependencies);
 
   // eslint-disable-next-line
-  console.warn(`\x1b[32mClearing dependencies exports from ${packageName}...\x1b[0m`);
+  console.warn(`\x1b[32mClearing unused dependencies exports from ${packageName}...\x1b[0m`);
 
   const works = [];
   fs.readdir('./', (err, files) => {
@@ -17,10 +18,13 @@ export default () => {
     files.forEach((file) => {
       if (fs.existsSync(file)
         && fs.statSync(file).isDirectory()
-        && excludedFolders.indexOf(file) === -1
-        && fs.existsSync(`${file}/.exported`)) {
+        && !excludedFolders.includes(file)
+        && fs.existsSync(`${file}/.exported`)
+        && !dependencies.includes(file)) {
         const work = fsp.remove(file);
         works.push(work);
+        // eslint-disable-next-line
+        console.warn(`\x1b[34mUnused dependency cleared: ${file}\x1b[0m`);
       }
     });
   });
@@ -28,6 +32,6 @@ export default () => {
   Promise.all(works)
     .then(() => {
       // eslint-disable-next-line
-      console.warn(`\x1b[32mDependencies exports cleared.\x1b[0m`);
+      console.warn(`\x1b[32mUnused dependencies exports cleared.\x1b[0m`);
     });
 };

--- a/scripts/export-modules.js
+++ b/scripts/export-modules.js
@@ -20,17 +20,19 @@ export default () => {
       fs.mkdirSync(dir);
     }
 
-    const exportContent = exportTemplate(dependency);
-    const work = fsp.writeFile(`${dir}/index.js`, exportContent)
-      .then(() => {
-        fsp.writeFile(`${dir}/.exported`, '');
-        // eslint-disable-next-line
-        console.warn(`\x1b[34mDependency exported: ${dependency}\x1b[0m`);
-      })
-      .catch((error) => {
-        throw new Error(error);
-      });
-    works.push(work);
+    if (!fs.existsSync(`${dir}/.exported`)) {
+      const exportContent = exportTemplate(dependency);
+      const work = fsp.writeFile(`${dir}/index.js`, exportContent)
+        .then(() => {
+          fsp.writeFile(`${dir}/.exported`, '');
+          // eslint-disable-next-line
+          console.warn(`\x1b[34mDependency exported: ${dependency}\x1b[0m`);
+        })
+        .catch((error) => {
+          throw new Error(error);
+        });
+      works.push(work);
+    }
   });
 
   Promise.all(works)


### PR DESCRIPTION
This PR modifies the clean and export modules script to leave the exporting files intact if they have been already generated. That enable us to use customize the export stubs, but at the same time rely on the scripts to clean export files for removed dependencies or generate them on new dependency addition automatically.

Story: [#143259835](https://www.pivotaltracker.com/story/show/143259835)